### PR TITLE
Fix self.className.startsWith is not a function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,9 @@ OverlayScrollbars.extension('scroll-chain', function (defaultOptions, framework,
         let foundViewport = false;
         let self = event.target;
         while (!foundViewport) {
-            if (!self)
+            if (!self) {
                 return false;
-            else if (self.className.startsWith('os-viewport')) {
+            } else if (self.className.startsWith('os-viewport')) {
                 foundViewport = true;
                 if (self !== instanceElements.viewport)
                     return false;

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ OverlayScrollbars.extension('scroll-chain', function (defaultOptions, framework,
         while (!foundViewport) {
             if (!self) {
                 return false;
-            } else if (self.className.startsWith('os-viewport')) {
+            } else if (self.className && self.className.startsWith('os-viewport')) {
                 foundViewport = true;
                 if (self !== instanceElements.viewport)
                     return false;


### PR DESCRIPTION
Track with sentry that sometimes plugin thrown an error
![image](https://user-images.githubusercontent.com/4497128/106473775-3f5f4b00-64b5-11eb-85ec-172b22afc867.png)

Maybe this happens because `shouldProcess` always return false or sometimes for empty div there are no classnames?

P.S: Using vue and make component wrapper for os plugin